### PR TITLE
feat: Adding Attachments to sent Emails

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,12 +34,14 @@ npm i worker-mailer
 ## Quick Start
 
 1. Configure your `wrangler.toml`:
+
 ```toml
 compatibility_flags = ["nodejs_compat"]
 # or compatibility_flags = ["nodejs_compat_v2"]
 ```
 
 2. Use in your code:
+
 ```typescript
 import { WorkerMailer } from 'worker-mailer'
 
@@ -61,7 +63,7 @@ await mailer.send({
   to: { name: 'Alice', email: 'alice@acme.com' },
   subject: 'Hello from Worker Mailer',
   text: 'This is a plain text message',
-  html: '<h1>Hello</h1><p>This is an HTML message</p>'
+  html: '<h1>Hello</h1><p>This is an HTML message</p>',
 })
 ```
 
@@ -73,17 +75,22 @@ Creates a new SMTP connection.
 
 ```typescript
 type WorkerMailerOptions = {
-  host: string;              // SMTP server hostname
-  port: number;              // SMTP server port (usually 587 or 465)
-  secure?: boolean;          // Use TLS (default: false)
-  credentials?: {            // SMTP authentication credentials
-    username: string;
-    password: string;
-  };
-  authType?: 'plain' | 'login' | 'cram-md5' | Array<'plain' | 'login' | 'cram-md5'>;
-  logLevel?: LogLevel;       // Logging level (default: LogLevel.INFO)
-  socketTimeoutMs?: number;  // Socket timeout in milliseconds
-  responseTimeoutMs?: number;// Server response timeout in milliseconds
+  host: string // SMTP server hostname
+  port: number // SMTP server port (usually 587 or 465)
+  secure?: boolean // Use TLS (default: false)
+  credentials?: {
+    // SMTP authentication credentials
+    username: string
+    password: string
+  }
+  authType?:
+    | 'plain'
+    | 'login'
+    | 'cram-md5'
+    | Array<'plain' | 'login' | 'cram-md5'>
+  logLevel?: LogLevel // Logging level (default: LogLevel.INFO)
+  socketTimeoutMs?: number // Socket timeout in milliseconds
+  responseTimeoutMs?: number // Server response timeout in milliseconds
 }
 ```
 
@@ -93,30 +100,52 @@ Sends an email.
 
 ```typescript
 type EmailOptions = {
-  from: string | {          // Sender's email
-    name?: string;
-    email: string;
-  };
-  to: string | string[] | { // Recipients (TO)
-    name?: string;
-    email: string;
-  } | Array<{ name?: string; email: string }>;
-  reply?: string | {        // Reply-To address
-    name?: string;
-    email: string;
-  };
-  cc?: string | string[] | { // Carbon Copy recipients
-    name?: string;
-    email: string;
-  } | Array<{ name?: string; email: string }>;
-  bcc?: string | string[] | { // Blind Carbon Copy recipients
-    name?: string;
-    email: string;
-  } | Array<{ name?: string; email: string }>;
-  subject: string;          // Email subject
-  text?: string;            // Plain text content
-  html?: string;            // HTML content
-  headers?: Record<string, string>; // Custom email headers
+  from:
+    | string
+    | {
+        // Sender's email
+        name?: string
+        email: string
+      }
+  to:
+    | string
+    | string[]
+    | {
+        // Recipients (TO)
+        name?: string
+        email: string
+      }
+    | Array<{ name?: string; email: string }>
+  reply?:
+    | string
+    | {
+        // Reply-To address
+        name?: string
+        email: string
+      }
+  cc?:
+    | string
+    | string[]
+    | {
+        // Carbon Copy recipients
+        name?: string
+        email: string
+      }
+    | Array<{ name?: string; email: string }>
+  bcc?:
+    | string
+    | string[]
+    | {
+        // Blind Carbon Copy recipients
+        name?: string
+        email: string
+      }
+    | Array<{ name?: string; email: string }>
+  subject: string // Email subject
+  text?: string // Plain text content
+  html?: string // HTML content
+  headers?: Record<string, string> // Custom email headers
+  attachments?: { filename: string; content: string; mimeType?: string }[] // Attachments, content must be base64-encoded, it will try to infer mimeType if not set
 }
 ```
 
@@ -132,16 +161,23 @@ await WorkerMailer.send(
     port: 587,
     credentials: {
       username: 'user',
-      password: 'pass'
-    }
+      password: 'pass',
+    },
   },
   {
     // EmailOptions
     from: 'sender@acme.com',
     to: 'recipient@acme.com',
     subject: 'Test',
-    text: 'Hello'
-  }
+    text: 'Hello',
+    attachments: [
+      {
+        filename: 'test.txt',
+        content: 'SGVsbG8gV29ybGQ=', // base64-encoded string for "Hello World"
+        type: 'text/plain',
+      },
+    ],
+  },
 )
 ```
 

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "tsup": "^8.2.3",
     "typescript": "^5.5.2",
     "vitest": "1.5.0",
-    "wrangler": "^3.60.3"
+    "wrangler": "^3.60.3",
+    "letterparser": "^0.1.8"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       '@types/node':
         specifier: ^20.14.12
         version: 20.14.12
+      letterparser:
+        specifier: ^0.1.8
+        version: 0.1.8
       prettier:
         specifier: ^3.3.3
         version: 3.3.3
@@ -790,6 +793,9 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
   better-path-resolve@1.0.0:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
     engines: {node: '>=4'}
@@ -1122,6 +1128,12 @@ packages:
 
   jsonfile@4.0.0:
     resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
+
+  lettercoder@0.0.7:
+    resolution: {integrity: sha512-Y8jW6TB69eoir8f5OCo2lulSxCqckPRQtWLyBGz7f+yaPL/nPfDsoLTzsVjl2d+ZEUh5nL0eS446LicJ+mqlJg==}
+
+  letterparser@0.1.8:
+    resolution: {integrity: sha512-mptxVUiQ9fO496nvjFnchVbExvpZSh0ktXaxU4OxkLjwzB/QlLx70oNP4NqmQ6JCBK74HfHBZDJliaw6qu9B1A==}
 
   lilconfig@3.1.2:
     resolution: {integrity: sha512-eop+wDAvpItUys0FWkHIKeC9ybYrTGbU41U5K7+bttZZeohvnY7M9dZ5kB21GNWiFT2q1OoPTvncPCgSOVO5ow==}
@@ -2383,6 +2395,8 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
+  base64-js@1.5.1: {}
+
   better-path-resolve@1.0.0:
     dependencies:
       is-windows: 1.0.2
@@ -2774,6 +2788,15 @@ snapshots:
   jsonfile@4.0.0:
     optionalDependencies:
       graceful-fs: 4.2.11
+
+  lettercoder@0.0.7:
+    dependencies:
+      base64-js: 1.5.1
+
+  letterparser@0.1.8:
+    dependencies:
+      base64-js: 1.5.1
+      lettercoder: 0.0.7
 
   lilconfig@3.1.2: {}
 

--- a/src/email.ts
+++ b/src/email.ts
@@ -1,5 +1,5 @@
 import { ok } from 'node:assert'
-import * as crypto from 'crypto'
+import * as crypto from 'node:crypto'
 
 export type User = { name?: string; email: string }
 
@@ -131,7 +131,14 @@ export class Email {
         emailData += `    creation-date="${new Date().toUTCString()}";\r\n`
         emailData += `Content-Transfer-Encoding: base64\r\n\r\n`
 
-        emailData += `${attachment.content}\r\n\r\n`
+        // split the content into multiple lines to avoid line length greater than 76 characters https://en.wikipedia.org/wiki/Base64#Variants_summary_table
+        const lines = attachment.content.match(/.{1,72}/g)
+        if (lines) {
+          emailData += `${lines.join('\r\n')}`
+        } else {
+          emailData += `${attachment.content}`
+        }
+        emailData += '\r\n\r\n'
       }
     }
     emailData += `--${mixedBoundary}--\r\n.\r\n`

--- a/src/email.ts
+++ b/src/email.ts
@@ -1,4 +1,5 @@
 import { ok } from 'node:assert'
+import * as crypto from 'crypto'
 
 export type User = { name?: string; email: string }
 
@@ -12,6 +13,7 @@ export type EmailOptions = {
   text?: string
   html?: string
   headers?: Record<string, string>
+  attachments?: { filename: string; content: string; mimeType?: string }[]
 }
 
 export class Email {
@@ -24,6 +26,12 @@ export class Email {
   public readonly subject: string
   public readonly text?: string
   public readonly html?: string
+
+  public readonly attachments?: {
+    filename: string
+    content: string
+    mimeType?: string
+  }[]
 
   public readonly headers: Record<string, string>
 
@@ -54,6 +62,7 @@ export class Email {
     this.subject = options.subject
     this.text = options.text
     this.html = options.html
+    this.attachments = options.attachments
     this.headers = options.headers || {}
   }
 
@@ -79,15 +88,81 @@ export class Email {
 
   public getEmailData() {
     this.resolveHeader()
-    const headersArray: string[] = []
+
+    const headersArray: string[] = ['MIME-Version: 1.0']
     for (const [key, value] of Object.entries(this.headers)) {
       headersArray.push(`${key}: ${value}`)
     }
+    const mixedBoundary = this.generateSafeBoundary('mixed_')
+    const alternativeBoundary = this.generateSafeBoundary('alternative_')
+
+    headersArray.push(
+      `Content-Type: multipart/mixed; boundary="${mixedBoundary}"`,
+    )
     const headers = headersArray.join('\r\n')
 
-    const body = this.html || this.text
+    let emailData = `${headers}\r\n\r\n`
+    emailData += `--${mixedBoundary}\r\n`
 
-    return `${headers}\r\n\r\n${body}\r\n.\r\n`
+    emailData += `Content-Type: multipart/alternative; boundary="${alternativeBoundary}"\r\n\r\n`
+
+    if (this.text) {
+      emailData += `--${alternativeBoundary}\r\n`
+      emailData += `Content-Type: text/plain; charset="UTF-8"\r\n\r\n`
+      emailData += `${this.text}\r\n\r\n`
+    }
+
+    if (this.html) {
+      emailData += `--${alternativeBoundary}\r\n`
+      emailData += `Content-Type: text/html; charset="UTF-8"\r\n\r\n`
+      emailData += `${this.html}\r\n\r\n`
+    }
+
+    emailData += `--${alternativeBoundary}--\r\n`
+
+    if (this.attachments) {
+      for (const attachment of this.attachments) {
+        const mimeType =
+          attachment.mimeType || this.getMimeType(attachment.filename)
+        emailData += `--${mixedBoundary}\r\n`
+        emailData += `Content-Type: ${mimeType}; name="${attachment.filename}"\r\n`
+        emailData += `Content-Description: ${attachment.filename}\r\n`
+        emailData += `Content-Disposition: attachment; filename="${attachment.filename}";\r\n`
+        emailData += `    creation-date="${new Date().toUTCString()}";\r\n`
+        emailData += `Content-Transfer-Encoding: base64\r\n\r\n`
+
+        emailData += `${attachment.content}\r\n\r\n`
+      }
+    }
+    emailData += `--${mixedBoundary}--\r\n.\r\n`
+
+    return emailData
+  }
+
+  private generateSafeBoundary(prefix: string): string {
+    let boundary = prefix + crypto.randomBytes(32).toString('hex')
+
+    boundary = boundary.replace(/[<>@,;:\\/[\]?=" ]/g, '_') // Replace unwanted characters with '_'
+
+    return boundary
+  }
+
+  private getMimeType(filename: string): string {
+    const extension = filename.split('.').pop()?.toLowerCase()
+
+    const mimeTypes: { [key: string]: string } = {
+      txt: 'text/plain',
+      html: 'text/html',
+      csv: 'text/csv',
+      pdf: 'application/pdf',
+      png: 'image/png',
+      jpg: 'image/jpeg',
+      jpeg: 'image/jpeg',
+      gif: 'image/gif',
+      zip: 'application/zip',
+    }
+
+    return mimeTypes[extension || 'txt'] || 'application/octet-stream' // Default to 'application/octet-stream'
   }
 
   private resolveHeader() {
@@ -97,7 +172,6 @@ export class Email {
     this.resolveCC()
     this.resolveBCC()
     this.resolveSubject()
-    this.resolveContentType()
     this.headers['Date'] = new Date().toUTCString()
     this.headers['Message-ID'] =
       `<${crypto.randomUUID()}@${this.from.email.split('@').pop()}>`
@@ -156,16 +230,6 @@ export class Email {
         return user.email
       })
       this.headers['BCC'] = bccAddresses.join(', ')
-    }
-  }
-
-  private resolveContentType() {
-    if (this.html) {
-      this.headers['Content-Type'] = 'text/html'
-    } else if (this.text) {
-      this.headers['Content-Type'] = 'text/plain'
-    } else {
-      this.headers['Content-Type'] = 'text/plain'
     }
   }
 }

--- a/test/src/email.test.ts
+++ b/test/src/email.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import { Email, type EmailOptions, type User } from '../../src/email'
+import { extract } from 'letterparser'
 
 describe('Email', () => {
   describe('constructor', () => {
@@ -8,7 +9,7 @@ describe('Email', () => {
         from: 'sender@example.com',
         to: 'recipient@example.com',
         subject: 'Test Subject',
-        text: 'Test content'
+        text: 'Test content',
       }
       const email = new Email(options)
       expect(email.from).toEqual({ email: 'sender@example.com' })
@@ -22,16 +23,19 @@ describe('Email', () => {
         from: { name: 'Sender Name', email: 'sender@example.com' },
         to: [
           { name: 'Recipient1', email: 'recipient1@example.com' },
-          { name: 'Recipient2', email: 'recipient2@example.com' }
+          { name: 'Recipient2', email: 'recipient2@example.com' },
         ],
         subject: 'Test Subject',
-        html: '<p>Test content</p>'
+        html: '<p>Test content</p>',
       }
       const email = new Email(options)
-      expect(email.from).toEqual({ name: 'Sender Name', email: 'sender@example.com' })
+      expect(email.from).toEqual({
+        name: 'Sender Name',
+        email: 'sender@example.com',
+      })
       expect(email.to).toEqual([
         { name: 'Recipient1', email: 'recipient1@example.com' },
-        { name: 'Recipient2', email: 'recipient2@example.com' }
+        { name: 'Recipient2', email: 'recipient2@example.com' },
       ])
     })
 
@@ -39,7 +43,7 @@ describe('Email', () => {
       const options: EmailOptions = {
         from: 'sender@example.com',
         to: 'recipient@example.com',
-        subject: 'Test Subject'
+        subject: 'Test Subject',
       }
       expect(() => new Email(options)).toThrow()
     })
@@ -51,26 +55,41 @@ describe('Email', () => {
         from: 'sender@example.com',
         to: 'recipient@example.com',
         subject: 'Test Subject',
-        text: 'Hello World'
+        text: 'Hello World',
       })
       const data = email.getEmailData()
-      expect(data).toContain('From: sender@example.com')
-      expect(data).toContain('To: recipient@example.com')
-      expect(data).toContain('Subject: Test Subject')
-      expect(data).toContain('Content-Type: text/plain')
-      expect(data).toContain('Hello World')
+      const msg = extract(data)
+      expect(msg.text).toBe('Hello World')
+      expect(msg.subject).toBe('Test Subject')
+      expect(msg.from).toEqual({
+        address: 'sender@example.com',
+        raw: 'sender@example.com',
+      })
+      expect(msg.to).toEqual([
+        { address: 'recipient@example.com', raw: 'recipient@example.com' },
+      ])
     })
 
-    it('should generate correct email data with HTML content', () => {
+    it('should generate correct email data with HTML and Text content', () => {
       const email = new Email({
         from: 'sender@example.com',
         to: 'recipient@example.com',
         subject: 'Test Subject',
-        html: '<p>Hello World</p>'
+        text: 'Hello World',
+        html: '<p>Hello World</p>',
       })
       const data = email.getEmailData()
-      expect(data).toContain('Content-Type: text/html')
-      expect(data).toContain('<p>Hello World</p>')
+      const msg = extract(data)
+      expect(msg.text).toBe('Hello World')
+      expect(msg.html).toBe('<p>Hello World</p>')
+      expect(msg.subject).toBe('Test Subject')
+      expect(msg.from).toEqual({
+        address: 'sender@example.com',
+        raw: 'sender@example.com',
+      })
+      expect(msg.to).toEqual([
+        { address: 'recipient@example.com', raw: 'recipient@example.com' },
+      ])
     })
 
     it('should include CC and BCC headers when provided', () => {
@@ -81,11 +100,21 @@ describe('Email', () => {
         cc: ['cc1@example.com', { name: 'CC2', email: 'cc2@example.com' }],
         bcc: 'bcc@example.com',
         subject: 'Test Subject',
-        text: 'Hello World'
+        text: 'Hello World',
       })
       const data = email.getEmailData()
-      expect(data).toContain('CC: cc1@example.com, CC2 <cc2@example.com>')
-      expect(data).toContain('BCC: bcc@example.com')
+      const msg = extract(data)
+      expect(msg.cc).toEqual([
+        { address: 'cc1@example.com', raw: 'cc1@example.com' },
+        {
+          address: 'cc2@example.com',
+          name: 'CC2',
+          raw: '"CC2" <cc2@example.com>',
+        },
+      ])
+      expect(msg.bcc).toEqual([
+        { address: 'bcc@example.com', raw: 'bcc@example.com' },
+      ])
     })
 
     it('should include Reply-To when provided', () => {
@@ -94,10 +123,17 @@ describe('Email', () => {
         to: 'recipient@example.com',
         reply: { name: 'Reply Name', email: 'reply@example.com' },
         subject: 'Test Subject',
-        text: 'Hello World'
+        text: 'Hello World',
       })
       const data = email.getEmailData()
-      expect(data).toContain('Reply-To: Reply Name <reply@example.com>')
+      const msg = extract(data)
+      expect(msg.replyTo).toEqual([
+        {
+          address: 'reply@example.com',
+          name: 'Reply Name',
+          raw: '"Reply Name" <reply@example.com>',
+        },
+      ])
     })
 
     it('should include custom headers when provided', () => {
@@ -107,12 +143,56 @@ describe('Email', () => {
         subject: 'Test Subject',
         text: 'Hello World',
         headers: {
-          'X-Custom-Header': 'Custom Value'
-        }
+          'X-Custom-Header': 'Custom Value',
+        },
       })
       const data = email.getEmailData()
+      // letterparser does not support headers yet
       expect(data).toContain('X-Custom-Header: Custom Value')
     })
+  })
+
+  it('should include attachments when provided', () => {
+    const email = new Email({
+      from: 'sender@example.com',
+      to: 'recipient@example.com',
+      subject: 'Test Subject',
+      text: 'Hello World',
+      attachments: [
+        {
+          filename: 'test.txt',
+          content: Buffer.from('Test content').toString('base64'),
+        },
+        {
+          filename: 'test2.txt',
+          content: Buffer.from('Test content 2').toString('base64'),
+        },
+      ],
+    })
+    const data = email.getEmailData()
+    const msg = extract(data)
+    expect(msg.attachments).toEqual([
+      {
+        filename: 'test.txt',
+        body: 'Test content',
+        contentId: undefined,
+        contentType: {
+          encoding: 'utf-8',
+          parameters: { name: 'test.txt' },
+          type: 'text/plain',
+        },
+      },
+      {
+        filename: 'test2.txt',
+        body: 'Test content 2',
+        contentId: undefined,
+        contentType: {
+          encoding: 'utf-8',
+          parameters: { name: 'test2.txt' },
+          type: 'text/plain',
+        },
+      },
+    ])
   })
 
   describe('sent promise', () => {
@@ -121,9 +201,9 @@ describe('Email', () => {
         from: 'sender@example.com',
         to: 'recipient@example.com',
         subject: 'Test Subject',
-        text: 'Hello World'
+        text: 'Hello World',
       })
-      
+
       setTimeout(() => email.setSent(), 0)
       await expect(email.sent).resolves.toBeUndefined()
     })
@@ -133,9 +213,9 @@ describe('Email', () => {
         from: 'sender@example.com',
         to: 'recipient@example.com',
         subject: 'Test Subject',
-        text: 'Hello World'
+        text: 'Hello World',
       })
-      
+
       const error = new Error('Test error')
       setTimeout(() => email.setSentError(error), 0)
       await expect(email.sent).rejects.toBe(error)


### PR DESCRIPTION
Hi,

thanks for the project! I made some small improvements to also support Attachments and also added the possibility of sending emails that are txt and html at the same time :D

I also included letterparser in the tests to make sure our email is properly parseable (thus dev dependencies). The dependencies do however remain none :).

### Email
- Added MIME-Version header.
- Adjusted email data generation to handle text, HTML, and attachments.
- Added logic to handle multiple attachments with appropriate MIME types and encoding.

### Tests
- added Tests for attachments
- refactored other tests to use letterparser

I also tested it locally (outside of the tests in this repo) by implementing it into a project to send attachments - and it works as before.