### PR TITLE
fix: Fixing Message ID

### DIFF
--- a/src/email.ts
+++ b/src/email.ts
@@ -100,7 +100,7 @@ export class Email {
     this.resolveContentType()
     this.headers['Date'] = new Date().toUTCString()
     this.headers['Message-ID'] =
-      `<${crypto.randomUUID()}@${this.from.email.split('@').pop()}>`
+      `<${crypto.randomUUID()}@${this.from.email.split('@').pop()?.replaceAll('<', '').replaceAll('>', '')}>`
   }
 
   private resolveFrom() {


### PR DESCRIPTION
Currently, the messageID can be `62265ba0-bc6c-4217-b4dc-be626e412ed5@example.com>` where the trailing `>` leads to it being invalid. This fixes that issue by removing the trailing `>`