### PR TITLE
Support UTF-8 to prevent InvalidCharacterError during SMTP auth

### DIFF
--- a/src/mailer.ts
+++ b/src/mailer.ts
@@ -1,5 +1,5 @@
 import { connect } from 'cloudflare:sockets'
-import { BlockingQueue, decode, encode, execTimeout } from './utils'
+import { BlockingQueue, decode, encode, base64Encode, execTimeout } from './utils'
 import { Email, EmailOptions } from './email'
 import Logger, { LogLevel } from './logger'
 
@@ -360,7 +360,7 @@ export class WorkerMailer {
   }
 
   private async authWithPlain() {
-    const userPassBase64 = btoa(
+    const userPassBase64 = base64Encode(
       `\u0000${this.credentials!.username}\u0000${this.credentials!.password}`,
     )
     await this.writeLine(`AUTH PLAIN ${userPassBase64}`)
@@ -377,14 +377,14 @@ export class WorkerMailer {
       throw new Error('Invalid login: ' + startLoginResponse)
     }
 
-    const usernameBase64 = btoa(this.credentials!.username)
+    const usernameBase64 = base64Encode(this.credentials!.username)
     await this.writeLine(usernameBase64)
     const userResponse = await this.readTimeout()
     if (!userResponse.startsWith('3')) {
       throw new Error('Failed to login authentication: ' + userResponse)
     }
 
-    const passwordBase64 = btoa(this.credentials!.password)
+    const passwordBase64 = base64Encode(this.credentials!.password)
     await this.writeLine(passwordBase64)
     const authResult = await this.readTimeout()
     if (!authResult.startsWith('2')) {
@@ -425,7 +425,7 @@ export class WorkerMailer {
       .join('')
 
     await this.writeLine(
-      btoa(`${this.credentials!.username} ${challengeSolved}`),
+      base64Encode(`${this.credentials!.username} ${challengeSolved}`),
     )
     const authResult = await this.readTimeout()
     if (!authResult.startsWith('2')) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -54,6 +54,16 @@ export function decode(data: Uint8Array): string {
   return decoder.decode(data)
 }
 
+export function base64Encode(str: string): string {
+  const bytes = encode(str)
+  let binString = ''
+  const chunkSize = 8192
+  for (let i = 0; i < bytes.length; i += chunkSize) {
+    binString += String.fromCharCode(...bytes.subarray(i, i + chunkSize))
+  }
+  return btoa(binString)
+}
+
 export function encodeQuotedPrintable(text: string, lineLength = 76): string {
   const bytes = encode(text)
   let result = ''

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -55,13 +55,13 @@ export function decode(data: Uint8Array): string {
 }
 
 export function base64Encode(str: string): string {
-  const bytes = encode(str)
-  let binString = ''
+  const chunks: string[] = []
   const chunkSize = 8192
+  const bytes = encode(str)
   for (let i = 0; i < bytes.length; i += chunkSize) {
-    binString += String.fromCharCode(...bytes.subarray(i, i + chunkSize))
+    chunks.push(String.fromCharCode(...bytes.subarray(i, i + chunkSize)))
   }
-  return btoa(binString)
+  return btoa(chunks.join(''))
 }
 
 export function encodeQuotedPrintable(text: string, lineLength = 76): string {

--- a/test/src/utils.test.ts
+++ b/test/src/utils.test.ts
@@ -120,7 +120,10 @@ describe('base64Encode', () => {
     const password = 'парола'
     
     const payload = `\u0000${username}\u0000${password}`
-    const expectedBase64 = 'AAnQvtGC0YDQtdCx0LjRgtC10L1AaHpuLmJnANGA0LDRgNC+0LvQsA=='
+    
+    // Using Buffer guarantees the expected base64 is accurately generated using Node's native bindings.
+    // It seamlessly adapts to any username or domain changes.
+    const expectedBase64 = Buffer.from(payload, 'utf-8').toString('base64')
     
     expect(base64Encode(payload)).toBe(expectedBase64)
   })
@@ -130,7 +133,7 @@ describe('base64Encode', () => {
   })
 
   it('should process very large strings in chunks without call stack errors', () => {
-    const largeCyrillic = 'тест'.repeat(2000) // 16,000 bytes (exceeds our 8192 chunk limit)
+    const largeCyrillic = 'тест'.repeat(2000)
     expect(() => base64Encode(largeCyrillic)).not.toThrow()
     
     const largeAscii = 'a'.repeat(20000)

--- a/test/src/utils.test.ts
+++ b/test/src/utils.test.ts
@@ -4,6 +4,7 @@ import {
   execTimeout,
   encode,
   decode,
+  base64Encode,
   encodeQuotedPrintable,
 } from '../../src/utils'
 import * as libqp from 'libqp'
@@ -100,6 +101,44 @@ describe('encode/decode', () => {
     const decoded = decode(encoded)
 
     expect(decoded).toBe(original)
+  })
+})
+
+describe('base64Encode', () => {
+  it('should encode standard ASCII strings exactly like btoa()', () => {
+    expect(base64Encode('testuser')).toBe('dGVzdHVzZXI=')
+    expect(base64Encode('password123')).toBe('cGFzc3dvcmQxMjM=')
+  })
+
+  it('should safely encode Cyrillic characters without throwing InvalidCharacterError', () => {
+    expect(base64Encode('тест')).toBe('0YLQtdGB0YI=')
+    expect(base64Encode('потребител')).toBe('0L/QvtGC0YDQtdCx0LjRgtC10Ls=')
+  })
+
+  it('should safely encode complex AUTH PLAIN payloads with Cyrillic characters', () => {
+    const username = 'потребител@example.bg'
+    const password = 'парола'
+    
+    const payload = `\u0000${username}\u0000${password}`
+    const expectedBase64 = 'AAnQvtGC0YDQtdCx0LjRgtC10L1AaHpuLmJnANGA0LDRgNC+0LvQsA=='
+    
+    expect(base64Encode(payload)).toBe(expectedBase64)
+  })
+
+  it('should safely encode Emoji and other multi-byte characters', () => {
+    expect(base64Encode('hello 🌍')).toBe('aGVsbG8g8J+MjQ==')
+  })
+
+  it('should process very large strings in chunks without call stack errors', () => {
+    const largeCyrillic = 'тест'.repeat(2000) // 16,000 bytes (exceeds our 8192 chunk limit)
+    expect(() => base64Encode(largeCyrillic)).not.toThrow()
+    
+    const largeAscii = 'a'.repeat(20000)
+    expect(base64Encode(largeAscii)).toBe(btoa(largeAscii))
+  })
+
+  it('should handle empty strings', () => {
+    expect(base64Encode('')).toBe('')
   })
 })
 


### PR DESCRIPTION
## Description
This PR fixes a bug where users with non-Latin characters (such as Cyrillic, Chinese, Arabic, etc.) in their email addresses or passwords encounter an `InvalidCharacterError` during SMTP authentication. 

### The Problem
The native JavaScript `btoa()` function strictly accepts only Latin1 (ISO/IEC 8859-1) characters. When `worker-mailer` attempts to encode credentials containing UTF-8 characters (e.g., for `AUTH PLAIN` or `AUTH LOGIN`), `btoa()` throws an exception and crashes the Worker.

### The Solution
Added a new `base64Encode` utility function in `src/utils.ts` which leverages `TextEncoder` to safely convert UTF-8 strings into byte arrays before base64 encoding them. I also replaced all direct `btoa()` calls in the authentication routines (`src/mailer.ts`) with the new safe `base64Encode` function.

### Testing Added
Added a comprehensive test block in `test/src/utils.test.ts` to verify `base64Encode` against:
- Standard ASCII strings
- Cyrillic / UTF-8 characters (verifying it doesn't throw)
- Simulated `AUTH PLAIN` byte payloads (verifying mathematical correctness using Node's `Buffer`)
- Emojis and multi-byte characters
- Large strings > 16,000 bytes (proving the 8,192 chunking logic works without blowing up the call stack)
- Empty strings

All tests pass successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated base64 encoding across authentication flows for more consistent and reliable authentication behavior.

* **Tests**
  * Added comprehensive tests covering ASCII, multi-byte characters, emoji, large inputs, and edge cases to ensure encoding robustness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->